### PR TITLE
[cmake] fix find package name and path mixed typography

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -1,9 +1,9 @@
 
-install(TARGETS ScopeGuard EXPORT ScopeGuard-config DESTINATION include)
+install(TARGETS ScopeGuard EXPORT ScopeGuardConfig DESTINATION include)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION include)
 
 if( ENABLE_COMPAT_HEADER )
     install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/" DESTINATION include)
 endif()
 
-install(EXPORT ScopeGuard-config DESTINATION share/scopeguard/cmake)
+install(EXPORT ScopeGuardConfig DESTINATION share/ScopeGuard/cmake)


### PR DESCRIPTION
Mixed camel-case and hyphenated-case prevent the CMake find package command to natively find the package, with error:
```CMake Warning at CMakeLists.txt:63 (find_package):
  By not providing "FindScopeGuard.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "ScopeGuard", but CMake did not find one.

  Could not find a package configuration file provided by "ScopeGuard" with
  any of the following names:

    ScopeGuardConfig.cmake
    scopeguard-config.cmake

  Add the installation prefix of "ScopeGuard" to CMAKE_PREFIX_PATH or set
  "ScopeGuard_DIR" to a directory containing one of the above files.  If
  "ScopeGuard" provides a separate development package or SDK, be sure it has
  been installed.
```

 
The fix is to use one or the other CMake suppoted naming standard (not mixing). Now, the error is resolved and `find_package(ScopeGuard)` works.