### PR TITLE
Use pipx in CI and drop some older compiler 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,10 @@ jobs:
           - gcc:13
           - gcc:12
           - gcc:11
-          - gcc:10
           - clang:18
           - clang:17
           - clang:16
           - clang:15
-          - clang:14
     container:
       image: "registry.gitlab.com/offa/docker-images/${{ matrix.compiler }}"
     name: "${{ matrix.compiler }}"

--- a/script/ci_build.sh
+++ b/script/ci_build.sh
@@ -5,9 +5,11 @@ set -ex
 BUILD_TYPE="Release"
 
 # Conan
+export DEBIAN_FRONTEND=noninteractive
+export PATH=$HOME/.local/bin:$PATH
 apt-get update
-apt-get install -y python3-pip
-pip3 install -U conan
+apt-get install -y pipx
+pipx install conan
 conan profile detect
 
 if [[ "${CXX}" == clang* ]]


### PR DESCRIPTION
Use pipx instead of pip and drop some older compiler, running on images, not supporting pipx, to fix #212.